### PR TITLE
Fix #198 No where to edit "Targets" and "Image modality" columns

### DIFF
--- a/software/cananolab-client-new/src/app/cananolab-client/main-display/samples/composition/nanomaterialentity/nanomaterialentity.component.html
+++ b/software/cananolab-client-new/src/app/cananolab-client/main-display/samples/composition/nanomaterialentity/nanomaterialentity.component.html
@@ -569,7 +569,6 @@
                                                 <tr>
                                                     <th>Function Type</th>
                                                     <th>Image Modality</th>
-                                                    <th>Targets</th>
                                                     <th>Description</th>
                                                     <th></th>
                                                 </tr>
@@ -579,9 +578,6 @@
                                                     </td>
                                                     <td>
                                                         {{iFunction.modality}}
-                                                    </td>
-                                                    <td>
-                                                        targets?
                                                     </td>
                                                     <td>
                                                         {{iFunction.description}}


### PR DESCRIPTION
Image Modailty column is still needed for "imaging function" type